### PR TITLE
Add KMS key to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,7 +4,8 @@ module.exports = {
     region: process.env.S3_REGION,
     accessKey: process.env.S3_ACCESS_KEY,
     secret: process.env.S3_SECRET,
-    bucket: process.env.S3_BUCKET
+    bucket: process.env.S3_BUCKET,
+    kms: process.env.S3_KMS_KEY_ID
   },
   db: {
     database: process.env.DATABASE_NAME,


### PR DESCRIPTION
ACP provisioned S3 buckets require KMS to be enabled, so we need to make sure that the config is passed through with uploads.