### PR TITLE
Handle case where no species are added to the ROP

### DIFF
--- a/lib/rops/index.js
+++ b/lib/rops/index.js
@@ -37,6 +37,9 @@ const getSubPurpose = procedure => {
 };
 
 const getOtherSpeciesGroup = (ropSpecies, procedure) => {
+  if (!ropSpecies) {
+    return '';
+  }
   if ((ropSpecies.otherSpecies || []).includes(procedure.species)) {
     return 'other-unspecified';
   }


### PR DESCRIPTION
If no species are added to the ROP manually, and only project species are used, then this throws an error because `ropSpecies` is undefined.

Return early in that case.