### PR TITLE
Add sub_purpose_other field to ROP procedures export

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "aws-sdk": "^2.874.0",
     "csv-stringify": "^5.6.2",
     "filenamify": "^4.2.0",
+    "lodash": "^4.17.21",
     "through2": "^4.0.2"
   }
 }


### PR DESCRIPTION
There are several fields in the ROP schema that store the other values, we need to fetch the correct one based on which type of sub purpose was selected.

We now explicitly whitelist the columns to be displayed in the `returns.csv`, as we need various ROPs properties for generating the `procedures.csv` that shouldn't be included.