### PR TITLE
Swap `species` and `otherSpecies` keys for non-coded species

### DIFF
--- a/lib/rops/index.js
+++ b/lib/rops/index.js
@@ -187,7 +187,11 @@ module.exports = ({ models, s3 }) => {
                 procs.forEach(p => {
                   p.subPurpose = getSubPurpose(p);
                   p.subPurposeOther = getSubPurposeOther(record, p);
-                  p.otherSpecies = getOtherSpeciesGroup(record.species, p);
+                  const otherSpecies = getOtherSpeciesGroup(record.species, p);
+                  if (otherSpecies) {
+                    p.otherSpecies = p.species;
+                    p.species = otherSpecies;
+                  }
                   procedures.write(p);
                 });
               }


### PR DESCRIPTION
This changes puts e.g. `other-birds` in the `species` column, and the free-text value into the `otherSpecies` column.

<img width="211" alt="Screenshot 2021-08-03 at 10 32 43" src="https://user-images.githubusercontent.com/117398/127994729-8d238ae0-c8cc-4346-af66-ded11b24abd8.png">
