### PR TITLE
Fix export error for regulatory and translational "other" subpurposes

### DIFF
--- a/lib/rops/index.js
+++ b/lib/rops/index.js
@@ -99,7 +99,7 @@ const getSubPurposeOther = (rop, procedure) => {
     'translationalSubpurposesOther'
   ].map(key => rop[key]));
 
-  return (others.find(other => other.id === id) || {}).value;
+  return (others.find(other => other && other.id === id) || {}).value;
 };
 
 function getLegislationOther(rop, procedure) {


### PR DESCRIPTION
If a subpurpose-other isn't used then it is null in the array and trying to read the id throws an error. Check that the "other" option is non-null before trying to match the id.