### PR TITLE
Always filter the columns to be displayed in the returns export

### DIFF
--- a/lib/rops/index.js
+++ b/lib/rops/index.js
@@ -224,7 +224,7 @@ module.exports = ({ models, s3 }) => {
           if (!record.id) {
             record.procedure_count = 0;
             record.status = 'not started';
-            return callback(null, record);
+            return callback(null, pick(record, returnsColumns));
           }
           Procedure.query()
             .where({ ropId: record.id })


### PR DESCRIPTION
When we switched to a whitelist for the returns columns, I filtered the columns for submitted returns ([see line 249](https://github.com/UKHomeOffice/asl-data-exports/blob/main/lib/rops/index.js#L249)), but I missed ROPs which hadn't been started, which meant the CSV contained all the ROPs columns and not just the whitelisted ones.