### PR TITLE
Remove product testing columns and add schedule 2 details

### DIFF
--- a/lib/rops/index.js
+++ b/lib/rops/index.js
@@ -53,8 +53,7 @@ const returnsColumns = [
   'general_anaesthesia_details',
   'rodenticide',
   'rodenticide_details',
-  'product_testing',
-  'product_testing_types',
+  'schedule_two_details',
   'procedure_count'
 ];
 


### PR DESCRIPTION
The product testing is only used to filter the procedure level input, and should not be included in the return.

Schedule 2 species details was missing and needed to be added.