### PR TITLE
Prevent too many db connections error

### DIFF
--- a/lib/task-metrics/index.js
+++ b/lib/task-metrics/index.js
@@ -30,9 +30,9 @@ module.exports = settings => {
     const query = { start, end };
 
     logger.debug('fetching internal-deadlines report');
-    const internalDeadlinesData = (await metrics('/reports/internal-deadlines', { stream: false, query }, accessToken)).filter(Boolean);
+    const internalDeadlinesData = await metrics('/reports/internal-deadlines', { stream: false, query }, accessToken);
     logger.debug('writing internal-deadlines csv');
-    internalDeadlinesData.forEach(row => internalDeadlinesCSV.write(row));
+    internalDeadlinesData.filter(Boolean).forEach(row => internalDeadlinesCSV.write(row));
     internalDeadlinesCSV.end();
 
     logger.debug('fetching actioned-tasks report');

--- a/lib/task-metrics/index.js
+++ b/lib/task-metrics/index.js
@@ -30,7 +30,7 @@ module.exports = settings => {
     const query = { start, end };
 
     logger.debug('fetching internal-deadlines report');
-    const internalDeadlinesData = await metrics('/reports/internal-deadlines', { stream: false, query }, accessToken);
+    const internalDeadlinesData = (await metrics('/reports/internal-deadlines', { stream: false, query }, accessToken)).filter(Boolean);
     logger.debug('writing internal-deadlines csv');
     internalDeadlinesData.forEach(row => internalDeadlinesCSV.write(row));
     internalDeadlinesCSV.end();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,7 +4,7 @@ const rops = require('./rops');
 const taskMetrics = require('./task-metrics');
 const Logger = require('./utils/logger');
 
-module.exports = settings => () => {
+module.exports = settings => {
   const logger = Logger(settings);
   settings.logger = logger;
 
@@ -18,7 +18,7 @@ module.exports = settings => () => {
 
   const { Export } = models;
 
-  const processExports = () => {
+  return () => {
     const start = performance.now();
     return Export.query()
       .where({ ready: false })
@@ -41,9 +41,8 @@ module.exports = settings => () => {
       .then(() => {
         const time = performance.now() - start;
         logger.info(`Processing took: ${time}ms`);
-      });
+      })
+      .then(() => models);
   };
 
-  return processExports()
-    .then(() => models);
 };


### PR DESCRIPTION
A new db connection was being opened every time the worker iterated and quickly exhausted the available pool.