### PR TITLE
Map `common-frogs` to `african-frogs` in ROPs export

### DIFF
--- a/lib/exporters/rops.js
+++ b/lib/exporters/rops.js
@@ -190,6 +190,14 @@ const normalise = record => {
   return record;
 };
 
+const normaliseSpecies = procedure => {
+  // Xenopus laevis are incorrectly coded as 'common-frogs', where they should be 'african-frogs'.
+  // Correct this on any procedures which have 'common-frogs'
+  if (procedure.species === 'common-frogs') {
+    procedure.species = 'african-frogs';
+  }
+};
+
 module.exports = ({ s3Upload, models }) => {
   const { Establishment, Project, Procedure } = models;
 
@@ -262,6 +270,7 @@ module.exports = ({ s3Upload, models }) => {
                   p.subPurposeOther = getSubPurposeOther(record, p);
                   p.legislationOther = getLegislationOther(record, p);
                   p.licenceNumber = record.licenceNumber;
+                  normaliseSpecies(p);
                   const otherSpecies = getOtherSpeciesGroup(record.species, p);
                   if (otherSpecies) {
                     p.otherSpecies = p.species;

--- a/test/specs/rops.js
+++ b/test/specs/rops.js
@@ -126,6 +126,17 @@ describe('ROPs Exporter', () => {
             newGeneticLine: false,
             severity: 'severe',
             severityNum: 200
+          },
+          {
+            ropId: ROP_ID,
+            species: 'common-frogs',
+            ga: 'false',
+            purposes: 'basic',
+            basicSubpurposes: 'oncology',
+            newGeneticLine: false,
+            severity: 'severe',
+            severityNum: 300,
+            severityHoNote: 'Common Frogs'
           }
         ]);
       });
@@ -194,7 +205,7 @@ describe('ROPs Exporter', () => {
       assert.equal(proj1.first_name, 'Test');
       assert.equal(proj1.last_name, 'User');
       assert.equal(proj1.status, 'submitted');
-      assert.equal(proj1.procedure_count, '2');
+      assert.equal(proj1.procedure_count, '3');
 
       assert.equal(proj2.first_name, 'Test');
       assert.equal(proj2.last_name, 'User');
@@ -252,6 +263,12 @@ describe('ROPs Exporter', () => {
 
     it('maps sub-purposes to single column', () => {
       assert.equal(this.procedures[0].sub_purpose, 'oncology');
+    });
+
+    it('maps common-frogs to african-frogs', () => {
+      const procedure = this.procedures.find(p => p.comments_for_ho === 'Common Frogs');
+      assert.ok(procedure);
+      assert.equal(procedure.species, 'african-frogs');
     });
 
   });


### PR DESCRIPTION
The species Xenopus Laevis is incorrectly coded in data. Make it not objectively wrong.